### PR TITLE
Remove deprecated extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "donjayamanne.githistory",
     "eamodio.gitlens",
     "editorconfig.editorconfig",
-    "eg2.vscode-npm-script",
     "esbenp.prettier-vscode",
     "flowtype.flow-for-vscode",
     "formulahendry.auto-close-tag",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ritwickdey.LiveServer",
     "robinbentley.sass-indented",
     "skyran.js-jsx-snippets",
-    "VisualStudioExptTeam.vscodeintellicode",
     "vscode-icons-team.vscode-icons",
     "usernamehw.errorlens",
     "wgenial.html-snippets",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "eamodio.gitlens",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
-    "flowtype.flow-for-vscode",
     "formulahendry.auto-close-tag",
     "formulahendry.auto-rename-tag",
     "GitHub.copilot",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "ms-python.python",
     "ms-vscode.vscode-typescript-next",
     "ms-vsliveshare.vsliveshare",
-    "msjsdiag.debugger-for-chrome",
     "NuclleaR.vscode-extension-auto-import",
     "patbenatar.advanced-new-file",
     "pflannery.vscode-versionlens",


### PR DESCRIPTION
These extensions are deprecated:
- IntelliCode
- NPM
- Debugger for Chrome

This extension I don't want anymore
- Flow